### PR TITLE
Add suspend (detach) support in order to Avoid un-used shaking.

### DIFF
--- a/ESP32_ServoSwitch.cpp
+++ b/ESP32_ServoSwitch.cpp
@@ -6,9 +6,10 @@
 uint32_t deg_to_pwm(int);
 /* prottype */
 
-ESP32_ServoSwitch::ESP32_ServoSwitch(uint8_t pin, uint8_t channel, int switch_off_deg, int switch_on_deg)
+ESP32_ServoSwitch::ESP32_ServoSwitch(uint8_t pin, uint8_t channel, int switch_off_deg, int switch_on_deg, bool is_suspend_enabled)
 {
     _channel = channel;
+    _pin = pin;
     _switch_off_deg = switch_off_deg;
     _switch_on_deg = switch_on_deg;
     _switch_mid_deg = (switch_on_deg + switch_off_deg) / 2;
@@ -16,12 +17,42 @@ ESP32_ServoSwitch::ESP32_ServoSwitch(uint8_t pin, uint8_t channel, int switch_of
     _target_deg = switch_off_deg;
     _current_deg = switch_off_deg;
 
+    _is_suspend_enabled = is_suspend_enabled;
+    _time_to_suspend = SERVO_SUSPEND_DELAY;
+    _is_suspend = false;
+
     ledcSetup(_channel, PWM_HZ, DUTY_BITRATE); // 16 bit = 65535
-    ledcAttachPin(pin, _channel);
+    ledcAttachPin(_pin, _channel);
+}
+
+ESP32_ServoSwitch::~ESP32_ServoSwitch()
+{
+    ESP32_ServoSwitch::suspend();
+}
+
+void ESP32_ServoSwitch::suspend()
+{
+    if (!_is_suspend)
+    {
+        ledcDetachPin(_pin);
+        _time_to_suspend = 0;
+    }
+    _is_suspend = true;
+}
+
+void ESP32_ServoSwitch::resume()
+{
+    if (_is_suspend)
+    {
+        ledcAttachPin(_pin, _channel);
+        _time_to_suspend = SERVO_SUSPEND_DELAY;
+    }
+    _is_suspend = false;
 }
 
 void ESP32_ServoSwitch::on()
 {
+
     _target_deg = _switch_on_deg;
 }
 
@@ -44,8 +75,16 @@ void ESP32_ServoSwitch::toggle()
 
 void ESP32_ServoSwitch::update()
 {
+    if (_current_deg == _target_deg)
+    {
+        _time_to_suspend = (((_time_to_suspend - 1) >= 0) ? (_time_to_suspend - 1) : 0);
+    }
+    else
+    {
+        _time_to_suspend = SERVO_SUSPEND_DELAY;
+    }
 
-    if (_current_deg <= _target_deg)
+    if (_current_deg < _target_deg)
     {
 
         if (_current_deg + SERVO_MOVINGSTEP_DEG <= _switch_on_deg)
@@ -57,7 +96,7 @@ void ESP32_ServoSwitch::update()
             _current_deg = _switch_on_deg;
         }
     }
-    else
+    else if (_current_deg > _target_deg)
     {
         if (_current_deg - SERVO_MOVINGSTEP_DEG > _switch_off_deg)
         {
@@ -68,8 +107,44 @@ void ESP32_ServoSwitch::update()
             _current_deg = _switch_off_deg;
         }
     }
+    else
+    {
+        _current_deg = _target_deg;
+    }
 
-    ledcWrite(_channel, deg_to_pwm(_current_deg));
+    if (!_is_suspend_enabled)
+    {
+        ledcWrite(_channel, deg_to_pwm(_current_deg));
+    }
+    else
+    {
+        if (_is_suspend)
+        {
+            if (_time_to_suspend > 0)
+            {
+                /* resume */
+                ESP32_ServoSwitch::resume();
+                ledcWrite(_channel, deg_to_pwm(_current_deg));
+            }
+            else
+            {
+                /* in suspend, nothing to do*/
+            }
+        }
+        else
+        {
+            if (_time_to_suspend <= 0)
+            {
+                /* go suspend */
+                ESP32_ServoSwitch::suspend();
+            }
+            else
+            {
+                /* normal output */
+                ledcWrite(_channel, deg_to_pwm(_current_deg));
+            }
+        }
+    }
 }
 
 bool ESP32_ServoSwitch::Is_state_on()
@@ -80,6 +155,11 @@ bool ESP32_ServoSwitch::Is_state_on()
 bool ESP32_ServoSwitch::Is_state_off()
 {
     return (_current_deg == _switch_off_deg);
+}
+
+bool ESP32_ServoSwitch::Is_suspend()
+{
+    return _is_suspend;
 }
 
 uint32_t deg_to_pwm(int deg)

--- a/ESP32_ServoSwitch.h
+++ b/ESP32_ServoSwitch.h
@@ -1,6 +1,6 @@
 /*ESP32_ServoSwitch.h - Library for control a Servo to toggle Switch.
   Created by Daichi SEKI, march 21, 2021.
-  Released into the public domain.*/
+  License : MIT */
 
 #ifndef esp32_servoSwitch_h
 #define esp32_servoSwitch_h
@@ -11,6 +11,7 @@
 #define SERVO_MIN_DEG int(0)        // servo min 0 deg
 #define SERVO_MAX_DEG int(180)      // servo max 180 deg
 #define SERVO_MOVINGSTEP_DEG int(1) // servo deg is increased x deg each update steps
+#define SERVO_SUSPEND_DELAY uint16_t(100) // times to suspend(detach) if suspend is enabled.
 
 // PWM parameters
 #define PWM_HZ double(50)
@@ -20,21 +21,29 @@
 class ESP32_ServoSwitch
 {
 public:
-  ESP32_ServoSwitch(uint8_t pin, uint8_t channel, int switch_off_deg, int switch_on_deg);
+  ESP32_ServoSwitch(uint8_t pin, uint8_t channel, int switch_off_deg, int switch_on_deg, bool is_suspend_enabled);
+  ~ESP32_ServoSwitch();
   void on();
   void off();
   void toggle();
   void update();
+  void suspend();
+  void resume();
   bool Is_state_on();
   bool Is_state_off();
+  bool Is_suspend();
 
 private:
-  int _channel;
+  uint8_t _channel;
+  uint8_t _pin;
   int _target_deg;
   int _current_deg;
   int _switch_off_deg;
   int _switch_on_deg;
   int _switch_mid_deg;
+  int _time_to_suspend;
+  bool _is_suspend;
+  bool _is_suspend_enabled;
 };
 
 uint32_t deg_to_pwm(float deg);


### PR DESCRIPTION
when "is_suspend_enabled" is true and spent "SERVO_SUSPEND_DELAY" times without no request, servo is detached.
After new request, servo is attached again.